### PR TITLE
Fixes issues #166 and #167 for excessive stdout warnings

### DIFF
--- a/generic_tracers/generic_COBALT.F90
+++ b/generic_tracers/generic_COBALT.F90
@@ -3548,7 +3548,7 @@ contains
     if (present(photo_acc_dpth)) then
       pha_all_same = all(photo_acc_dpth == photo_acc_dpth(isc,jsc))
       if (pha_all_same) then
-        call mpp_error(WARNING, "Using uniform photoacclimation MLD in COBALTv3 which is not reccomended."//&
+        call mpp_error(FATAL, "Using uniform photoacclimation MLD in COBALTv3 which is not reccomended."//&
                                 "Check that PHA_MLD_CALC is true in the MOM paramter files or you "//&
                                 "may be using an unrealistic constant value!")
       endif

--- a/generic_tracers/generic_tracer_utils.F90
+++ b/generic_tracers/generic_tracer_utils.F90
@@ -3713,12 +3713,6 @@ contains
        g_tracer => g_tracer%next
     enddo
 
-    if(errorstring .ne. '') then
-       !The following cannot be FATAL for backward compatibility with MOM5 and GOLD
-       call mpp_error(WARNING, trim(sub_name) // ' : there are tracers with required source properties that are not set '//&
-                      'in the field_table. Grep the stdout for NOTEs from g_tracer_print_info and correct the field_table!')
-    endif
-
     if (verbose >= 3) then
        write(errorstring, '(a,i4)')  ': Number of prognostic generic tracers = ',num_prog
        call mpp_error(NOTE, trim(sub_name) //  trim(errorstring))


### PR DESCRIPTION
- Closes issue #166, the printing of missing source entries in field_table is repeated and unnecessary
- Closes issue #167, Using uniform photoacclimation MLD should stop the run at the onset so the user can correct it